### PR TITLE
修复了三星爆率过高的bug

### DIFF
--- a/nonebot_plugin_bawiki/data/gacha.py
+++ b/nonebot_plugin_bawiki/data/gacha.py
@@ -443,6 +443,8 @@ async def do_gacha(
         ]
         if i % 10 != 0:
             pool_and_weight.append((star_1_base["char"], star_1_chance))
+        else:
+            pool_and_weight.append((star_2_base["char"], star_1_chance))
 
         pool_and_weight = [x for x in pool_and_weight if x[0]]
         pool = [x[0] for x in pool_and_weight]


### PR DESCRIPTION
第十张卡保底二星，但是因为你是用weight来取概率，所以不能少加一星卡的概率权值，而是替换成二星卡。
另外bawikidata的gache.json该把三星概率换成3%而不是2.5%了